### PR TITLE
feat: Add RTOS synchronization + timer demo (Week 4–5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,24 @@ feat: Add task communication demo (global variable vs FreeRTOS queue)
 - **Queue Demo:** Increment + Reset tasks push data safely into a queue, Print task retrieves values in FIFO order without corruption  
 - Demonstrates how FreeRTOS queues solve the limitations of globals by providing atomic, ordered, and synchronized task communication  
 - Clear serial logs highlight the contrast: globals cause overwrites, queues guarantee message delivery  
+
+
+### Week 4–5 – 11/10/2025  
+feat: Add task synchronization and software timer demo  
+
+- **Semaphore Demo:**  
+  Two tasks safely share the Serial port using a **binary semaphore**.  
+  Demonstrates how FreeRTOS ensures mutual exclusion and avoids data overlap when multiple tasks access the same shared resource.  
+
+- **Software Timer Demo:**  
+  Introduces FreeRTOS **software timers** to perform periodic actions without blocking any task.  
+  A timer toggles an LED every 1 second, showing how timers offload periodic tasks from the main scheduler.  
+
+- **Combined Concept:**  
+  Both features are integrated into a single example while the timer toggles an LED, two concurrent tasks print messages using semaphore protection.  
+  This illustrates how synchronization (🔒) and periodic events (⏱️) can coexist smoothly in a multitasking RTOS system.  
+
+- Clear serial logs and LED toggle behavior highlight:  
+  ✅ Safe resource access via semaphores  
+  ✅ Non-blocking periodic actions via software timers  
+  ✅ Deterministic and modular task management under FreeRTOS  

--- a/RTOS Series Week-4-5/SemaphoreSoftTimer/SemaphoreSoftTimer.ino
+++ b/RTOS Series Week-4-5/SemaphoreSoftTimer/SemaphoreSoftTimer.ino
@@ -1,0 +1,68 @@
+//===============================================================================
+// Project Name : RTOS Essentials Learning Series
+// Author       : Vivek Patel
+// Date         : 11/10/2025
+// Description  : Combined Demo – Task Synchronization + Software Timer
+//                Two tasks share Serial safely using a semaphore.
+//                A software timer toggles an LED every 1 second.
+//===============================================================================
+#include <Arduino_FreeRTOS.h>
+#include <semphr.h>
+#include <timers.h>
+//===============================================================================
+#define LED_PIN 13
+//===============================================================================
+SemaphoreHandle_t xSerialSemaphore;
+TimerHandle_t xLedTimer;
+//===============================================================================
+void vTaskA(void *pvParameters) {
+  (void) pvParameters;
+  for (;;) {
+    if (xSemaphoreTake(xSerialSemaphore, (TickType_t)10) == pdTRUE) {
+      Serial.println("Task A running...");
+      xSemaphoreGive(xSerialSemaphore);
+    }
+    vTaskDelay(500 / portTICK_PERIOD_MS);
+  }
+}
+//===============================================================================
+void vTaskB(void *pvParameters) {
+  (void) pvParameters;
+  for (;;) {
+    if (xSemaphoreTake(xSerialSemaphore, (TickType_t)10) == pdTRUE) {
+      Serial.println("Task B running...");
+      xSemaphoreGive(xSerialSemaphore);
+    }
+    vTaskDelay(700 / portTICK_PERIOD_MS);
+  }
+}
+//===============================================================================
+void vLedTimerCallback(TimerHandle_t xTimer) {
+  digitalWrite(LED_PIN, !digitalRead(LED_PIN));
+}
+//===============================================================================
+void setup() {
+  Serial.begin(9600);
+  pinMode(LED_PIN, OUTPUT);
+
+  // Create semaphore for Serial access
+  xSerialSemaphore = xSemaphoreCreateBinary();
+  xSemaphoreGive(xSerialSemaphore);
+
+  // Create LED timer – 1 s auto-reload
+  xLedTimer = xTimerCreate("LEDTimer",
+                           1000 / portTICK_PERIOD_MS,
+                           pdTRUE,
+                           (void*)0,
+                           vLedTimerCallback);
+  if (xLedTimer != NULL) xTimerStart(xLedTimer, 0);
+
+  // Create tasks
+  xTaskCreate(vTaskA, "TaskA", 128, NULL, 1, NULL);
+  xTaskCreate(vTaskB, "TaskB", 128, NULL, 1, NULL);
+
+  vTaskStartScheduler();
+}
+//===============================================================================
+void loop() {}
+//===============================================================================


### PR DESCRIPTION
Introduces FreeRTOS binary semaphore for safe access to shared resources (Serial).

Demonstrates mutual exclusion where multiple tasks print without data overlap.

Adds FreeRTOS software timer to toggle LED every 1 second without blocking tasks.

Shows how timers enable periodic events independently of main task scheduling.

Combines both concepts: timer (⏱️) + semaphore (🔒) for concurrent, non-blocking system behavior.

Illustrates synchronization and periodic actions coexisting smoothly under FreeRTOS.

Updated README.md with Week 4–5 (11/10/2025) entry.