### PR TITLE
feat: Add RTOS task priorities and preemption demo (Week 6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,30 @@ feat: Add task synchronization and software timer demo
   This illustrates how synchronization (🔒) and periodic events (⏱️) can coexist smoothly in a multitasking RTOS system.  
 
 - Clear serial logs and LED toggle behavior highlight:  
-  ✅ Safe resource access via semaphores  
-  ✅ Non-blocking periodic actions via software timers  
-  ✅ Deterministic and modular task management under FreeRTOS  
+  • Safe resource access via semaphores  
+  • Non-blocking periodic actions via software timers  
+  • Deterministic and modular task management under FreeRTOS  
+
+
+### Week 6 – 18/10/2025  
+feat: Add task priorities and preemption demo  
+
+- **Concept Overview:**  
+  Demonstrates how FreeRTOS schedules multiple tasks based on their **priority levels**.  
+  A higher-priority task always preempts (interrupts) a lower-priority one whenever it becomes ready to run.  
+  This behavior is at the heart of FreeRTOS’s real-time deterministic scheduling.  
+
+- **Demo (Arduino Uno):**  
+  • **Low Priority Task (Priority 1):** Simulates heavy CPU work to occupy processor time.  
+  • **High Priority Task (Priority 2):** Periodically wakes up and interrupts the low-priority task to run first.  
+  • Both tasks print messages on the Serial Monitor, making preemption clearly visible.  
+
+- **Key Observations:**  
+  • High-priority task takes control whenever it becomes ready, regardless of what the low-priority task is doing.  
+  • Scheduler automatically handles context switching between tasks.  
+  • Serial output shows the low task’s “heavy work” being interrupted mid-cycle by the high-priority task.  
+
+- **Takeaway:**  
+  FreeRTOS preemptive scheduling ensures that time-critical tasks always get CPU access when needed.  
+  Task priorities are a powerful mechanism to control system responsiveness and deterministic behavior in embedded systems.  
+

--- a/RTOS Series Week-6/TaskPriorityPreemption/TaskPriorityPreemption.ino
+++ b/RTOS Series Week-6/TaskPriorityPreemption/TaskPriorityPreemption.ino
@@ -1,0 +1,59 @@
+//===============================================================================
+// Project Name : RTOS Essentials Learning Series
+// Author       : Vivek Patel
+// Date         : 18/10/2025
+// Description  : Task Priorities and Preemption Demonstration (Enhanced)
+//                This version makes preemption visibly clear by simulating
+//                heavy work in the low-priority task.
+//===============================================================================
+#include <Arduino_FreeRTOS.h>
+//======================Function Prototypes======================================
+void vHighPriorityTask(void *pvParameters);
+void vLowPriorityTask(void *pvParameters);
+//==============================Setup============================================
+void setup() {
+  Serial.begin(9600);
+  while (!Serial) { ; }
+
+  Serial.println("RTOS Week 6: Task Priorities & Preemption (Enhanced)");
+  Serial.println("==============================================================");
+
+  // Low priority = 1
+  xTaskCreate(vLowPriorityTask, "LowTask", 128, NULL, 1, NULL);
+
+  // High priority = 2
+  xTaskCreate(vHighPriorityTask, "HighTask", 128, NULL, 2, NULL);
+
+  vTaskStartScheduler();
+}
+//================================================================================
+void loop() {
+  // Not used when running FreeRTOS
+}
+//=================================Tasks==========================================
+// High Priority Task - prints periodically
+void vHighPriorityTask(void *pvParameters) {
+  (void) pvParameters;
+  for (;;) {
+    Serial.println("🔺 High Priority Task INTERRUPT!");
+    vTaskDelay(1000 / portTICK_PERIOD_MS);
+  }
+}
+//===============================================================================
+// Low Priority Task - simulates heavy processing
+void vLowPriorityTask(void *pvParameters) {
+  (void) pvParameters;
+
+  for (;;) {
+    Serial.println("⬇️ Low Priority Task starting heavy work...");
+    // Simulate CPU-intensive work (~300ms loop)
+    for (volatile uint32_t i = 0; i < 600000; i++) {
+      // dummy math to consume time
+      uint8_t dummy = i % 10;
+      (void)dummy;
+    }
+    Serial.println("⬇️ Low Priority Task finished cycle.");
+    vTaskDelay(100 / portTICK_PERIOD_MS);
+  }
+}
+//================================================================================


### PR DESCRIPTION
Demonstrates how FreeRTOS scheduler handles multiple tasks with different priorities.

Shows that a higher-priority task preempts a lower-priority one whenever it becomes ready.

Low-priority task simulates heavy CPU work, while high-priority task interrupts periodically.

Serial output clearly illustrates task preemption behavior in real time.

Enhances understanding of FreeRTOS scheduler, priority handling, and context switching.

Updated README.md with Week 6 (18/10/2025) entry.