### PR TITLE
feat: Add ESP32 dual-core scheduling demo (Week 7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,27 @@ feat: Add task priorities and preemption demo
   FreeRTOS preemptive scheduling ensures that time-critical tasks always get CPU access when needed.  
   Task priorities are a powerful mechanism to control system responsiveness and deterministic behavior in embedded systems.  
 
+
+### Week 7 – 09/11/2025  
+feat: Add ESP32 dual-core scheduling demo  
+
+- **Concept Overview:**  
+  ESP32 runs FreeRTOS natively on **two cores** (Core 0 and Core 1).  
+  This demo shows how tasks can be explicitly assigned to a specific core using  
+  `xTaskCreatePinnedToCore()`, enabling true parallel execution.
+
+- **Demo (ESP32):**  
+  • **TaskLED (Core 0):** Toggles the onboard LED every 500ms  
+  • **TaskCompute (Core 1):** Performs Fibonacci calculations and prints results  
+  • Both tasks run independently on separate CPU cores
+
+- **Key Observations:**  
+  • LED blinks smoothly on Core 0 while heavy computations run on Core 1  
+  • Serial output shows each task’s core using `xPortGetCoreID()`  
+  • Demonstrates *real parallelism*, not just time-sliced multitasking  
+  • Validates dual-core FreeRTOS scheduling and core affinity on ESP32
+
+- **Takeaway:**  
+  ESP32 provides a powerful upgrade for RTOS development — dual-core scheduling  
+  allows CPU-intensive tasks and hardware I/O to run seamlessly in parallel,  
+  significantly improving responsiveness and system throughput.

--- a/RTOS Series Week-7/esp32-dualcore/esp32-dualcore.ino
+++ b/RTOS Series Week-7/esp32-dualcore/esp32-dualcore.ino
@@ -1,0 +1,94 @@
+//===============================================================================
+// Project Name : RTOS Essentials Learning Series
+// Author       : Vivek Patel
+// Date         : 09/11/2025
+// Description  : Dual-Core Scheduling Demonstration (ESP32)
+//                Demonstrates true parallel execution:
+//                - Core 0: LED blink task
+//                - Core 1: CPU-intensive compute task
+//===============================================================================
+
+#include <Arduino.h>
+
+// Define LED pin (built-in LED on ESP32 Dev boards is usually GPIO 2)
+#define LED_PIN 2
+
+TaskHandle_t TaskLED_Handle;
+TaskHandle_t TaskCompute_Handle;
+
+//--------------------------------------------------------------------
+// Task 1 - LED blink (Core 0)
+//--------------------------------------------------------------------
+void TaskLED(void *pvParameters) {
+  pinMode(LED_PIN, OUTPUT);
+
+  for (;;) {
+    digitalWrite(LED_PIN, !digitalRead(LED_PIN));  // toggle LED
+    Serial.print("💡 LED toggled on Core ");
+    Serial.println(xPortGetCoreID());
+    vTaskDelay(500 / portTICK_PERIOD_MS);
+  }
+}
+
+//--------------------------------------------------------------------
+// Task 2 - CPU Intensive work (Core 1)
+//--------------------------------------------------------------------
+void TaskCompute(void *pvParameters) {
+  uint32_t n1 = 0, n2 = 1, n3;
+
+  for (;;) {
+    // Compute a small Fibonacci sequence (simulate heavy work)
+    for (int i = 0; i < 10; i++) {
+      n3 = n1 + n2;
+      n1 = n2;
+      n2 = n3;
+    }
+
+    Serial.print("⚙️ Compute Task running on Core ");
+    Serial.print(xPortGetCoreID());
+    Serial.print(" | Fibonacci value: ");
+    Serial.println(n3);
+
+    vTaskDelay(700 / portTICK_PERIOD_MS);
+  }
+}
+
+//--------------------------------------------------------------------
+// Setup
+//--------------------------------------------------------------------
+void setup() {
+  Serial.begin(115200);
+  delay(1000);
+
+  Serial.println("==================================================");
+  Serial.println("RTOS Series – Week 7: Dual-Core Scheduling Demo");
+  Serial.println("==================================================");
+
+  Serial.printf("ESP32 FreeRTOS running on %d cores\n\n", portNUM_PROCESSORS);
+
+  // Create LED task pinned to Core 0
+  xTaskCreatePinnedToCore(
+    TaskLED,             // Function
+    "TaskLED",           // Name
+    2048,                // Stack size
+    NULL,                // Parameters
+    1,                   // Priority
+    &TaskLED_Handle,     // Task handle
+    0                    // Core 0
+  );
+
+  // Create Compute task pinned to Core 1
+  xTaskCreatePinnedToCore(
+    TaskCompute,         // Function
+    "TaskCompute",       // Name
+    4096,                // Stack size (bigger for computation)
+    NULL,                // Parameters
+    1,                   // Priority
+    &TaskCompute_Handle, // Task handle
+    1                    // Core 1
+  );
+}
+
+void loop() {
+  // Empty - tasks are managed by FreeRTOS scheduler
+}


### PR DESCRIPTION
Introduces ESP32 FreeRTOS dual-core task management example.

Implements two independent tasks pinned to specific cores using xTaskCreatePinnedToCore().

TaskLED (Core 0) handles onboard LED toggling every 500ms.

TaskCompute (Core 1) performs Fibonacci calculations and prints results periodically.

Demonstrates true parallel execution across ESP32's dual cores.

Validates FreeRTOS core affinity, real parallelism, and multi-core scheduling behavior.

Updated README.md with Week 7 (09/11/2025) entry.